### PR TITLE
rust: Add rust_buffer module example

### DIFF
--- a/samples/rust/Kconfig
+++ b/samples/rust/Kconfig
@@ -70,6 +70,16 @@ config SAMPLE_RUST_MISCDEV
 
 	  If unsure, say N.
 
+config SAMPLE_RUST_BUFFER
+	tristate "File buffer"
+	help
+	  This option builds the Rust file buffer sample.
+
+	  To compile this as a module, choose M here:
+	  the module will be called rust_buffer.
+
+	  If unsure, say N.
+
 config SAMPLE_RUST_STACK_PROBING
 	tristate "Stack probing"
 	help

--- a/samples/rust/Makefile
+++ b/samples/rust/Makefile
@@ -6,6 +6,7 @@ obj-$(CONFIG_SAMPLE_RUST_MODULE_PARAMETERS)	+= rust_module_parameters.o
 obj-$(CONFIG_SAMPLE_RUST_SYNC)			+= rust_sync.o
 obj-$(CONFIG_SAMPLE_RUST_CHRDEV)		+= rust_chrdev.o
 obj-$(CONFIG_SAMPLE_RUST_MISCDEV)		+= rust_miscdev.o
+obj-$(CONFIG_SAMPLE_RUST_BUFFER)		+= rust_buffer.o
 obj-$(CONFIG_SAMPLE_RUST_STACK_PROBING)		+= rust_stack_probing.o
 obj-$(CONFIG_SAMPLE_RUST_SEMAPHORE)		+= rust_semaphore.o
 obj-$(CONFIG_SAMPLE_RUST_SEMAPHORE_C)		+= rust_semaphore_c.o

--- a/samples/rust/rust_buffer.rs
+++ b/samples/rust/rust_buffer.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Rust memory-backed file.
+//!
+//! Allocate a buffer of shared kernel memory and expose this buffer to user-space using a misc
+//! file device interface.
+
+use kernel::{
+    file::{self, File},
+    io_buffer::{IoBufferReader, IoBufferWriter},
+    prelude::*,
+};
+
+module_misc_device! {
+    type: RustBuffer,
+    name: "rust_buffer",
+    author: "Andrea Righi <andrea.righi@canonical.com>",
+    description: "Memory-backed file implemented in Rust",
+    license: "GPL v2",
+}
+
+// Size of the shared memory buffer (4K by default)
+const BUFSIZE : usize = 4096usize;
+
+// Shared memory buffer
+static mut BUFFER: [u8; BUFSIZE] = [0u8; BUFSIZE];
+
+struct RustBuffer {
+}
+
+#[vtable]
+impl file::Operations for RustBuffer {
+    type Data = Box<Self>;
+
+    fn open(_context: &Self::OpenData, _file: &File) -> Result<Self::Data> {
+        Ok(Box::try_new(Self { })?)
+    }
+
+    fn read(_this: &Self, _: &File, buf: &mut impl IoBufferWriter, offset: u64) -> Result<usize> {
+        let mut total_len = 0;
+        let off : usize = offset.try_into().unwrap();
+
+        while !buf.is_empty() {
+            let start : usize = off + total_len;
+            let len = buf.len().min(BUFSIZE - start);
+            if len <= 0 {
+                break;
+            }
+            unsafe {
+                buf.write_slice(&BUFFER[start .. start + len])?;
+            }
+            total_len += len;
+        }
+        Ok(total_len)
+    }
+
+    fn write(_this: &Self, _: &File, buf: &mut impl IoBufferReader, offset: u64) -> Result<usize> {
+        let mut total_len = 0;
+        let off : usize = offset.try_into().unwrap();
+
+        while !buf.is_empty() {
+            let start : usize = off + total_len;
+            let len = buf.len().min(BUFSIZE - start);
+            if len <= 0 {
+                break;
+            }
+            unsafe {
+                buf.read_slice(&mut BUFFER[start .. start + len])?;
+            }
+            total_len += len;
+        }
+        Ok(total_len)
+    }
+}


### PR DESCRIPTION
This modules provides access to a shared buffer of kernel memory and expose it to user-space using a misc file device interface, via /dev/rust_buffer.

Signed-off-by: Andrea Righi <andrea.righi@canonical.com>